### PR TITLE
fix(diagnostics): correct previous diagnostic keymap

### DIFF
--- a/lua/klepp0/remap.lua
+++ b/lua/klepp0/remap.lua
@@ -18,7 +18,7 @@ vim.keymap.set("n", "<Esc>", "<cmd>nohlsearch<CR>")
 
 -- Diagnostic keymaps
 vim.keymap.set("n", "<C-n>", vim.diagnostic.goto_next, { desc = "Go to [n]ext diagnostic message" })
-vim.keymap.set("n", "<C-N>", vim.diagnostic.goto_prev, { desc = "Go to previous diagnostic message" })
+vim.keymap.set("n", "<C-p>", vim.diagnostic.goto_prev, { desc = "Go to [p]revious diagnostic message" })
 vim.keymap.set("n", "<leader>e", vim.diagnostic.open_float, { desc = "Show diagnostic [E]rror messages" })
 vim.keymap.set("n", "<leader>q", vim.diagnostic.setloclist, { desc = "Open diagnostic [Q]uickfix list" })
 


### PR DESCRIPTION
## Summary
- avoid overriding `<C-n>` diagnostic mapping by remapping previous to `<C-p>`

## Testing
- `luac -p lua/klepp0/remap.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed; 403)*
- `npm test` *(fails: Missing script 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a57c42b4b883228c16f96905a55936