### PR TITLE
fix: correct vertical bar comment typo

### DIFF
--- a/lua/klepp0/set.lua
+++ b/lua/klepp0/set.lua
@@ -75,7 +75,7 @@ vim.opt.smartindent = true
 -- Enable 24-bit RGB color in the TUI
 vim.opt.termguicolors = true
 
--- Set vertical bar at the 120th charactor as orientation for the line length
+-- Show a vertical bar at the 120th character as a guideline for line length
 vim.opt.colorcolumn = "120"
 
 -- Highlight when yanking (copying) text


### PR DESCRIPTION
## Summary
- fix typo in color column comment

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a580da5780832298acbe4b6f04cc1b