### PR TITLE
feat: map diagnostic previous to Ctrl-P

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ To unlock the full potential of Telescope and see the stars (or just find your f
 - [fd](https://github.com/sharkdp/fd): The swift and nimble finder, blessed by the gods of efficiency.
 
 Install these, and you'll be navigating your code like a wizard in no time!
+
+### Diagnostics 🩺
+
+Navigate diagnostics quickly:
+
+- `<C-n>`: Go to next diagnostic message
+- `<C-p>`: Go to previous diagnostic message
+- `<leader>e`: Show diagnostic error messages
+- `<leader>q`: Open diagnostic quickfix list

--- a/lua/klepp0/remap.lua
+++ b/lua/klepp0/remap.lua
@@ -18,7 +18,7 @@ vim.keymap.set("n", "<Esc>", "<cmd>nohlsearch<CR>")
 
 -- Diagnostic keymaps
 vim.keymap.set("n", "<C-n>", vim.diagnostic.goto_next, { desc = "Go to [n]ext diagnostic message" })
-vim.keymap.set("n", "<C-N>", vim.diagnostic.goto_prev, { desc = "Go to previous diagnostic message" })
+vim.keymap.set("n", "<C-p>", vim.diagnostic.goto_prev, { desc = "Go to previous diagnostic message" })
 vim.keymap.set("n", "<leader>e", vim.diagnostic.open_float, { desc = "Show diagnostic [E]rror messages" })
 vim.keymap.set("n", "<leader>q", vim.diagnostic.setloclist, { desc = "Open diagnostic [Q]uickfix list" })
 


### PR DESCRIPTION
## Summary
- remap diagnostic previous message shortcut to `<C-p>`
- document diagnostic navigation shortcuts in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a58109a03883228a59b3080bcec017