### PR TITLE
Add Bats test for install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,15 @@ To unlock the full potential of Telescope and see the stars (or just find your f
 - [fd](https://github.com/sharkdp/fd): The swift and nimble finder, blessed by the gods of efficiency.
 
 Install these, and you'll be navigating your code like a wizard in no time!
+
+## Tests
+
+This repository includes a small shell test suite using [Bats](https://bats-core.readthedocs.io/).
+Install `bats` and run the tests with:
+
+```sh
+bats tests
+```
+
+The tests simulate a user configuration directory in a temporary location, so they do not
+modify your real `~/.config` directory.

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_DIR="${BATS_TEST_DIRNAME}/.."
+  export HOME="$BATS_TMPDIR/home"
+  mkdir -p "$HOME"
+}
+
+teardown() {
+  rm -rf "$HOME"
+}
+
+@test "install.sh backs up existing nvim config and links repo" {
+  mkdir -p "$HOME/.config/nvim"
+  touch "$HOME/.config/nvim/example"
+
+  run bash -c "cd \"$REPO_DIR\" && printf 'y\\n' | HOME=\"$HOME\" ./install.sh"
+
+  [ "$status" -eq 0 ]
+  [ -d "$HOME/.config/nvim.bak" ]
+  [ -f "$HOME/.config/nvim.bak/example" ]
+  [ -L "$HOME/.config/nvim" ]
+
+  run readlink "$HOME/.config/nvim"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$REPO_DIR" ]
+}


### PR DESCRIPTION
## Summary
- add Bats-based test covering install.sh backup and symlink behavior
- document how to run the Bats tests in README

## Testing
- `bats tests/install.bats` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5812332c8832299bdf35ad5946df3