### PR TITLE
feat: configure ruff formatter

### DIFF
--- a/after/plugin/conform.lua
+++ b/after/plugin/conform.lua
@@ -24,13 +24,18 @@ conform.setup({
 
   -- Formatter-specific config
   formatters = {
-    -- ensure import sorting with rule I and resolve project root for ruff
+    -- run Ruff import fixes and code formatter from the project root
     ruff_fix = {
-      prepend_args = { "--select", "I" },
+      command = "ruff",
+      args = { "--fix", "--select", "I", "--stdin-filename", "$FILENAME", "-" },
       cwd = util.root_file({ "pyproject.toml", "ruff.toml", ".ruff.toml" }),
+      stdin = true,
     },
     ruff_format = {
+      command = "ruff",
+      args = { "format", "--stdin-filename", "$FILENAME", "-" },
       cwd = util.root_file({ "pyproject.toml", "ruff.toml", ".ruff.toml" }),
+      stdin = true,
     },
   },
 })


### PR DESCRIPTION
## Summary
- run Ruff import fixes and formatter on save

## Testing
- `nvim --headless '+luafile after/plugin/conform.lua' +q` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba95b834d88322ab8ef93a56fc51a5